### PR TITLE
Quoted passwords

### DIFF
--- a/src-tests/data/test6a.netrc
+++ b/src-tests/data/test6a.netrc
@@ -1,0 +1,1 @@
+default login abc password """"

--- a/src-tests/data/test6a.netrc.out
+++ b/src-tests/data/test6a.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6a.netrc.out2
+++ b/src-tests/data/test6a.netrc.out2
@@ -1,0 +1,1 @@
+default login abc

--- a/src-tests/data/test6b.netrc
+++ b/src-tests/data/test6b.netrc
@@ -1,0 +1,1 @@
+default login abc password ""multi-word password""

--- a/src-tests/data/test6b.netrc.out
+++ b/src-tests/data/test6b.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "multi-word password", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6b.netrc.out2
+++ b/src-tests/data/test6b.netrc.out2
@@ -1,1 +1,1 @@
-default login abc password multi-word password
+default login abc password ""multi-word password""

--- a/src-tests/data/test6b.netrc.out2
+++ b/src-tests/data/test6b.netrc.out2
@@ -1,0 +1,1 @@
+default login abc password multi-word password

--- a/src-tests/data/test6c.netrc
+++ b/src-tests/data/test6c.netrc
@@ -1,0 +1,1 @@
+default login abc password ""unescape \\ backslash""

--- a/src-tests/data/test6c.netrc.out
+++ b/src-tests/data/test6c.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "unescape \\ backslash", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6c.netrc.out2
+++ b/src-tests/data/test6c.netrc.out2
@@ -1,0 +1,1 @@
+default login abc password unescape \ backslash

--- a/src-tests/data/test6c.netrc.out2
+++ b/src-tests/data/test6c.netrc.out2
@@ -1,1 +1,1 @@
-default login abc password unescape \ backslash
+default login abc password ""unescape \\ backslash""

--- a/src-tests/data/test6d.netrc
+++ b/src-tests/data/test6d.netrc
@@ -1,0 +1,1 @@
+default login abc password ""unescape \" quote""

--- a/src-tests/data/test6d.netrc.out
+++ b/src-tests/data/test6d.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "unescape \" quote", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6d.netrc.out2
+++ b/src-tests/data/test6d.netrc.out2
@@ -1,0 +1,1 @@
+default login abc password unescape " quote

--- a/src-tests/data/test6d.netrc.out2
+++ b/src-tests/data/test6d.netrc.out2
@@ -1,1 +1,1 @@
-default login abc password unescape " quote
+default login abc password ""unescape \" quote""

--- a/src-tests/data/test6e.netrc
+++ b/src-tests/data/test6e.netrc
@@ -1,0 +1,1 @@
+default login abc password ""unclosed-double-quotes

--- a/src-tests/data/test6e.netrc.out
+++ b/src-tests/data/test6e.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "\"\"unclosed-double-quotes", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6e.netrc.out2
+++ b/src-tests/data/test6e.netrc.out2
@@ -1,0 +1,1 @@
+default login abc password ""unclosed-double-quotes

--- a/src-tests/data/test6f.netrc
+++ b/src-tests/data/test6f.netrc
@@ -1,0 +1,1 @@
+default login abc password ""password with # comment""

--- a/src-tests/data/test6f.netrc.out
+++ b/src-tests/data/test6f.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "password with # comment", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6f.netrc.out2
+++ b/src-tests/data/test6f.netrc.out2
@@ -1,0 +1,1 @@
+default login abc password password with # comment

--- a/src-tests/data/test6f.netrc.out2
+++ b/src-tests/data/test6f.netrc.out2
@@ -1,1 +1,1 @@
-default login abc password password with # comment
+default login abc password ""password with # comment""

--- a/src-tests/data/test6g.netrc
+++ b/src-tests/data/test6g.netrc
@@ -1,0 +1,1 @@
+default login abc password "single # quote should be treated as normal password"

--- a/src-tests/data/test6g.netrc.out
+++ b/src-tests/data/test6g.netrc.out
@@ -1,0 +1,1 @@
+Right (NetRc {nrHosts = [NetRcHost {nrhName = "", nrhLogin = "abc", nrhPassword = "\"single", nrhAccount = "", nrhMacros = []}], nrMacros = []})

--- a/src-tests/data/test6g.netrc.out2
+++ b/src-tests/data/test6g.netrc.out2
@@ -1,0 +1,1 @@
+default login abc password "single

--- a/src/Network/NetRc.hs
+++ b/src/Network/NetRc.hs
@@ -27,6 +27,10 @@
 -- and after @machine@\/@default@\/@macdef@ entries. Be aware though
 -- that such @#@-comment are not supported by all @.netrc@-aware
 -- applications, including @ftp(1)@.
+--
+-- Passwords can contain spaces only if they are double-quoted, in which
+-- case backslashes and quotes are to be escaped with a preceding backslash.
+
 module Network.NetRc
     ( -- * Types
       NetRc(..)


### PR DESCRIPTION
Re https://github.com/haskell-hvr/netrc/issues/12, allows for double-quoted passwords to contain spaces. Escapes backslash and quotes with backslash prefix.

I think I've covered most of the potential backtracking problems with the tests, but please take a look to make sure I'm not missing anything obvious.

The BNF in the blurb is severely complicated by this feature. I'm not too sure whether we should attempt to specify `<value>` accurately (in which case I would definitely need assistance), or if we should just expect users to read the remarks underneath.

Also, could you please advise on the style and string API usage in `netRcToBuilder`? It feels like it could be tidier, and I'm not 100% sure I'm building the strings optimally.

Lastly, FParsec recommends against using the monadic form for performance reasons, but I wonder if it might be a bit easier to read than the combinators, i.e.:

```
quotedPassword = do
  _ <- P.string "\"\""
  p <- P.many chars
  _ <- P.string "\"\""
  return $ BC.pack p
```

Thanks!