### PR TITLE
v0.2.0.2: build with GHC 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["github","netrc.cabal"])
+# REGENDATA ("0.19.20250821",["github","netrc.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -110,11 +115,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,9 +244,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_netrc}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package netrc" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package netrc" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package netrc" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(netrc)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## 0.2.0.2
+
+_Andreas Abel, 2025-09-02_
+
+  - Remove obsolete `deriving Typeable`.
+  - Remove old code for GHC 7.
+  - Fix warnings.
+  - Tested with GHC 8.0 - 9.14 alpha1.
+
 ## 0.2.0.1
 
 _Andreas Abel, 2024-06-25_

--- a/netrc.cabal
+++ b/netrc.cabal
@@ -1,6 +1,6 @@
-cabal-version:       >=1.10
+cabal-version:       1.18
 name:                netrc
-version:             0.2.0.1
+version:             0.2.0.2
 synopsis:            Parser for .netrc files
 homepage:            https://github.com/haskell-hvr/netrc
 bug-reports:         https://github.com/haskell-hvr/netrc/issues
@@ -19,6 +19,7 @@ description:
 
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4
@@ -33,8 +34,10 @@ tested-with:
   GHC == 8.2.2
   GHC == 8.0.2
 
-extra-source-files:
+extra-doc-files:
   changelog.md
+
+extra-source-files:
   src-tests/data/*.netrc
   src-tests/data/*.netrc.out
 
@@ -48,11 +51,12 @@ library
     OverloadedStrings
     RecordWildCards
 
+  -- Lower bounds taken from GHC 8.0 and Stackage LTS 7.0
   build-depends:
       base                  >= 4.9        && < 5
-    , deepseq               >= 1.3        && < 1.6
-    , bytestring            >= 0.10.4     && < 0.13
-    , parsec                >= 3.1        && < 3.2
+    , deepseq               >= 1.4.2.0    && < 1.6
+    , bytestring            >= 0.10.8.0   && < 0.13
+    , parsec                >= 3.1.11     && < 3.2
 
   hs-source-dirs: src
   exposed-modules: Network.NetRc
@@ -71,9 +75,9 @@ test-suite test-netrc
       netrc
     , base
     , bytestring
-    , tasty                 >= 0.10       && < 1.6
+    , tasty                 >= 0.11.0.4   && < 1.6
     , tasty-golden          == 2.3.*
-    , tasty-quickcheck      >= 0.8.1      && < 1
+    , tasty-quickcheck      >= 0.8.4      && < 1
 
 source-repository head
   type: git

--- a/src-tests/test-netrc.hs
+++ b/src-tests/test-netrc.hs
@@ -39,13 +39,13 @@ main = do
     let goTests = testGroup "ref-samples"
                   [ goldenVsString tn (fp++".out") (doGoTest fp)
                   | fp <- sort netrcFiles
-                  , let Just tn = stripPrefix "src-tests/data/" fp
+                  , let tn = fromMaybe undefined $ stripPrefix "src-tests/data/" fp
                   ]
 
     let goTests2 = testGroup "ref-samples2"
                   [ goldenVsString tn (fp++".out2") (doGoTest2 fp)
                   | fp <- sort netrcFiles
-                  , let Just tn = stripPrefix "src-tests/data/" fp
+                  , let tn = fromMaybe undefined $ stripPrefix "src-tests/data/" fp
                   ]
 
     defaultMain $ testGroup "Tests" [goTests, goTests2, qcTests]

--- a/src/Network/NetRc.hs
+++ b/src/Network/NetRc.hs
@@ -72,7 +72,7 @@ data NetRcHost = NetRcHost
     , nrhPassword  :: !ByteString   -- ^ @password@ property (@""@ if missing)
     , nrhAccount   :: !ByteString   -- ^ @account@ property (@""@ if missing)
     , nrhMacros    :: [NetRcMacDef] -- ^ associated @macdef@ entries
-    } deriving (Eq,Ord,Show,Typeable,Data,Generic)
+    } deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData NetRcHost where rnf !_ = ()
 
@@ -84,7 +84,7 @@ data NetRcMacDef = NetRcMacDef
     , nrmBody :: !ByteString -- ^ Raw @macdef@ body
                              --
                              -- __Invariant__: must not contain null-lines, i.e. consecutive @LF@s
-    } deriving (Eq,Ord,Show,Typeable,Data,Generic)
+    } deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData NetRcMacDef where rnf !_ = ()
 
@@ -105,7 +105,7 @@ data NetRc = NetRc
                                 -- associated with host-entries are
                                 -- invisible to some applications
                                 -- (e.g. @ftp(1)@).
-    } deriving (Eq,Ord,Show,Typeable,Data,Generic)
+    } deriving (Eq, Ord, Show, Data, Generic)
 
 instance NFData NetRc where
     rnf (NetRc ms ds) = ms `deepseq` ds `deepseq` ()


### PR DESCRIPTION
- **No longer derive Typeable (obsolete since GHC 7.10)**
  

- **Remove conditional code obsolete with GHC >= 8**
  

- **Fix import warning for foldl'**
  

- **Bump to 0.2.0.2 and CHANGELOG; bump Haskell CI to GHC 9.14 alpha1**
  

Candidate: https://hackage.haskell.org/package/netrc-0.2.0.2/candidate